### PR TITLE
Implement limit offset with optimized tx-add map

### DIFF
--- a/endpoints/get_address_transactions.py
+++ b/endpoints/get_address_transactions.py
@@ -86,19 +86,19 @@ async def get_transactions_for_address_v2(
     ):
     """
     Get all transactions for a given address from database.
-    And then get their related full transactiond data
+    And then get their related full transaction data
     """
 
     async with async_session() as s:
         # Doing it this way as opposed to adding it directly in the IN clause
         # so I can re-use the same result in tx_list, TxInput and TxOutput
-        txWithinLimitOffset = await s.execute(select(TxAddrMapping.transaction_id)
+        tx_within_limit_offset = await s.execute(select(TxAddrMapping.transaction_id)
             .filter(TxAddrMapping.address == kaspaAddress)
             .limit(limit)
             .offset(offset)
             .order_by(TxAddrMapping.block_time.desc())
         )
 
-        txIdsInPage = [x[0] for x in txWithinLimitOffset.all()]
+        tx_ids_in_page = [x[0] for x in tx_within_limit_offset.all()]
 
-    return await search_for_transactions(TxSearch(transactionIds=txIdsInPage), fields)
+    return await search_for_transactions(TxSearch(transactionIds=tx_ids_in_page), fields)

--- a/endpoints/get_address_transactions.py
+++ b/endpoints/get_address_transactions.py
@@ -64,11 +64,11 @@ async def get_transactions_for_address(
         "transactions": tx_list
     }
 
-@app.get("/addresses/{kaspaAddress}/transactions/v2",
+@app.get("/addresses/{kaspaAddress}/full-transactions",
          response_model=List[TxModel],
          response_model_exclude_unset=True,
-         tags=["Kaspa addresses transactions"])
-async def get_transactions_for_address_v2(
+         tags=["Kaspa addresses"])
+async def get_full_transactions_for_address(
         kaspaAddress: str = Path(
             description="Kaspa address as string e.g. "
                         "kaspa:pzhh76qc82wzduvsrd9xh4zde9qhp0xc8rl7qu2mvl2e42uvdqt75zrcgpm00",

--- a/endpoints/get_address_transactions.py
+++ b/endpoints/get_address_transactions.py
@@ -1,13 +1,16 @@
 # encoding: utf-8
 from typing import List
 
-from fastapi import Path
+from fastapi import Path, Query
 from pydantic import BaseModel
 from sqlalchemy import text
+from sqlalchemy.future import select
+from endpoints.get_transactions import search_for_transactions, TxSearch, TxModel
 
 from dbsession import async_session
 from server import app
 
+from models.TxAddrMapping import TxAddrMapping
 
 class TransactionsReceivedAndSpent(BaseModel):
     tx_received: str
@@ -60,3 +63,42 @@ async def get_transactions_for_address(
     return {
         "transactions": tx_list
     }
+
+@app.get("/addresses/{kaspaAddress}/transactions/v2",
+         response_model=List[TxModel],
+         response_model_exclude_unset=True,
+         tags=["Kaspa addresses transactions"])
+async def get_transactions_for_address_v2(
+        kaspaAddress: str = Path(
+            description="Kaspa address as string e.g. "
+                        "kaspa:pzhh76qc82wzduvsrd9xh4zde9qhp0xc8rl7qu2mvl2e42uvdqt75zrcgpm00",
+            regex="^kaspa\:[a-z0-9]{61}$"),
+        limit: int = Query(
+            description="The number of records to get",
+            ge=1,
+            le=500,
+            default=50),
+        offset: int = Query(
+            description="The offset from which to get records",
+            ge=0,
+            default=0),
+        fields: str = "",
+    ):
+    """
+    Get all transactions for a given address from database.
+    And then get their related full transactiond data
+    """
+
+    async with async_session() as s:
+        # Doing it this way as opposed to adding it directly in the IN clause
+        # so I can re-use the same result in tx_list, TxInput and TxOutput
+        txWithinLimitOffset = await s.execute(select(TxAddrMapping.transaction_id)
+            .filter(TxAddrMapping.address == kaspaAddress)
+            .limit(limit)
+            .offset(offset)
+            .order_by(TxAddrMapping.block_time.desc())
+        )
+
+        txIdsInPage = [x[0] for x in txWithinLimitOffset.all()]
+
+    return await search_for_transactions(TxSearch(transactionIds=txIdsInPage), fields)

--- a/endpoints/get_transactions.py
+++ b/endpoints/get_transactions.py
@@ -123,7 +123,8 @@ async def search_for_transactions(txSearch: TxSearch,
     async with async_session() as s:
         tx_list = await s.execute(select(Transaction, Block.blue_score)
                                   .join(Block, Transaction.accepting_block_hash == Block.hash, isouter=True)
-                                  .filter(Transaction.transaction_id.in_(txSearch.transactionIds)))
+                                  .filter(Transaction.transaction_id.in_(txSearch.transactionIds))
+                                  .order_by(Transaction.block_time.desc()))
 
         tx_list = tx_list.all()
 

--- a/models/TxAddrMapping.py
+++ b/models/TxAddrMapping.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String, BigInteger, Boolean
+
+from dbsession import Base
+
+class TxAddrMapping(Base):
+    __tablename__ = 'tx_id_address_mapping'
+    transaction_id = Column(String)
+    address = Column(String)
+    block_time = Column(BigInteger)
+    is_accepted = Column(Boolean, default=False)
+    id = Column(BigInteger, primary_key=True)


### PR DESCRIPTION
Add the endpoint that returns all transactions within a given limit and offset

New endpoint: /address/{address}/transctions/v2 (we can replace this or rename this however we want)

This combines the old functionality of /address/{address}/transactions and /transactions/search and includes usage of the optimization table `tx_id_address_mapping`.

Depends on:
- `tx_id_address_mapping` existing and fully filled

Notes:
- Does not include `is_accepted` filtering yet