### PR TITLE
Resolve inputs' previous outpoint directly

### DIFF
--- a/endpoints/get_address_transactions.py
+++ b/endpoints/get_address_transactions.py
@@ -13,6 +13,10 @@ from server import app
 
 from models.TxAddrMapping import TxAddrMapping
 
+DESC_RESOLVE_PARAM = "Use this parameter if you want to fetch the TransactionInput previous outpoint details." \
+                     " Light fetches only the address and amount. Full fetches the whole TransactionOutput and " \
+                     "adds it into each TxInput."
+
 
 class TransactionsReceivedAndSpent(BaseModel):
     tx_received: str
@@ -32,6 +36,7 @@ class PreviousOutpointLookupMode(str, Enum):
     no = "no"
     light = "light"
     full = "full"
+
 
 @app.get("/addresses/{kaspaAddress}/transactions",
          response_model=TransactionForAddressResponse,
@@ -97,8 +102,9 @@ async def get_full_transactions_for_address(
             ge=0,
             default=0),
         fields: str = "",
-        resolve_previous_outputs: PreviousOutpointLookupMode = "no"
-):
+        resolve_previous_outpoints: PreviousOutpointLookupMode =
+        Query(default="no",
+              description=DESC_RESOLVE_PARAM)):
     """
     Get all transactions for a given address from database.
     And then get their related full transaction data
@@ -118,7 +124,7 @@ async def get_full_transactions_for_address(
 
     return await search_for_transactions(TxSearch(transactionIds=tx_ids_in_page),
                                          fields,
-                                         resolve_previous_outputs)
+                                         resolve_previous_outpoints)
 
 
 @app.get("/addresses/{kaspaAddress}/transactions-count",

--- a/endpoints/get_address_transactions.py
+++ b/endpoints/get_address_transactions.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from enum import Enum
 from typing import List
 
 from fastapi import Path, Query
@@ -26,6 +27,11 @@ class TransactionForAddressResponse(BaseModel):
 class TransactionCount(BaseModel):
     total: int
 
+
+class PreviousOutpointLookupMode(str, Enum):
+    no = "no"
+    light = "light"
+    full = "full"
 
 @app.get("/addresses/{kaspaAddress}/transactions",
          response_model=TransactionForAddressResponse,
@@ -91,7 +97,7 @@ async def get_full_transactions_for_address(
             ge=0,
             default=0),
         fields: str = "",
-        resolve_previous_outputs: bool = False
+        resolve_previous_outputs: PreviousOutpointLookupMode = "no"
 ):
     """
     Get all transactions for a given address from database.

--- a/endpoints/get_address_transactions.py
+++ b/endpoints/get_address_transactions.py
@@ -12,6 +12,7 @@ from server import app
 
 from models.TxAddrMapping import TxAddrMapping
 
+
 class TransactionsReceivedAndSpent(BaseModel):
     tx_received: str
     tx_spent: str | None
@@ -20,6 +21,7 @@ class TransactionsReceivedAndSpent(BaseModel):
 
 class TransactionForAddressResponse(BaseModel):
     transactions: List[TransactionsReceivedAndSpent]
+
 
 class TransactionCount(BaseModel):
     total: int
@@ -69,6 +71,7 @@ async def get_transactions_for_address(
         "transactions": tx_list
     }
 
+
 @app.get("/addresses/{kaspaAddress}/full-transactions",
          response_model=List[TxModel],
          response_model_exclude_unset=True,
@@ -88,7 +91,8 @@ async def get_full_transactions_for_address(
             ge=0,
             default=0),
         fields: str = "",
-    ):
+        resolve_previous_outputs: bool = False
+):
     """
     Get all transactions for a given address from database.
     And then get their related full transaction data
@@ -98,21 +102,24 @@ async def get_full_transactions_for_address(
         # Doing it this way as opposed to adding it directly in the IN clause
         # so I can re-use the same result in tx_list, TxInput and TxOutput
         tx_within_limit_offset = await s.execute(select(TxAddrMapping.transaction_id)
-            .filter(TxAddrMapping.address == kaspaAddress)
-            .limit(limit)
-            .offset(offset)
-            .order_by(TxAddrMapping.block_time.desc())
-        )
+                                                 .filter(TxAddrMapping.address == kaspaAddress)
+                                                 .limit(limit)
+                                                 .offset(offset)
+                                                 .order_by(TxAddrMapping.block_time.desc())
+                                                 )
 
         tx_ids_in_page = [x[0] for x in tx_within_limit_offset.all()]
 
-    return await search_for_transactions(TxSearch(transactionIds=tx_ids_in_page), fields)
+    return await search_for_transactions(TxSearch(transactionIds=tx_ids_in_page),
+                                         fields,
+                                         resolve_previous_outputs)
+
 
 @app.get("/addresses/{kaspaAddress}/transactions-count",
          response_model=TransactionCount,
          tags=["Kaspa addresses"])
 async def get_transaction_count_for_address(
-    kaspaAddress: str = Path(
+        kaspaAddress: str = Path(
             description="Kaspa address as string e.g. "
                         "kaspa:pzhh76qc82wzduvsrd9xh4zde9qhp0xc8rl7qu2mvl2e42uvdqt75zrcgpm00",
             regex="^kaspa\:[a-z0-9]{61,63}$")

--- a/endpoints/get_transactions.py
+++ b/endpoints/get_transactions.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-import time
+
 from enum import Enum
 from typing import List
 
@@ -84,7 +84,7 @@ async def get_transaction(transactionId: str = Path(regex="[a-f0-9]{64}"),
                           inputs: bool = True,
                           outputs: bool = True,
                           resolve_previous_outpoints: PreviousOutpointLookupMode =
-                          Query(default="no",
+                          Query(default=PreviousOutpointLookupMode.no,
                                 description=DESC_RESOLVE_PARAM)):
     """
     Get block information for a given block id
@@ -109,11 +109,8 @@ async def get_transaction(transactionId: str = Path(regex="[a-f0-9]{64}"),
             if resolve_previous_outpoints in ["light", "full"]:
                 tx_inputs = await s.execute(select(TransactionInput, TransactionOutput)
                                             .outerjoin(TransactionOutput,
-                                                       (
-                                                               TransactionOutput.transaction_id == TransactionInput.previous_outpoint_hash) &
-                                                       (TransactionOutput.index == cast(
-                                                           TransactionInput.previous_outpoint_index, Integer)),
-                                                       )
+                                                       (TransactionOutput.transaction_id == TransactionInput.previous_outpoint_hash) &
+                                                       (TransactionOutput.index == cast(TransactionInput.previous_outpoint_index, Integer)))
                                             .filter(TransactionInput.transaction_id == transactionId))
 
                 tx_inputs = tx_inputs.all()
@@ -166,7 +163,7 @@ async def get_transaction(transactionId: str = Path(regex="[a-f0-9]{64}"),
 async def search_for_transactions(txSearch: TxSearch,
                                   fields: str = "",
                                   resolve_previous_outpoints: PreviousOutpointLookupMode =
-                                  Query(default="no",
+                                  Query(default=PreviousOutpointLookupMode.no,
                                         description=DESC_RESOLVE_PARAM)):
     """
     Get block information for a given block id


### PR DESCRIPTION
I've added a parameter resolve_previous_outpoints, which goes through the input, takes the previous_outpoint_hash and index, and fetches TxOutput.

In light mode, it adds only addr + amount to save the data
In full mode, the full TxOutput gets added to the input.