### PR TITLE
Calculate TransactionOutput.script_public_key_type

### DIFF
--- a/helper/PublicKeyType.py
+++ b/helper/PublicKeyType.py
@@ -1,0 +1,44 @@
+SCRIPT_CLASS_PUB_KEY = 'pubkey'
+SCRIPT_CLASS_PUB_KEY_ECDSA = 'pubkeyecdsa'
+SCRIPT_CLASS_SCRIPT_HASH = 'scripthash'
+SCRIPT_CLASS_NON_STANDARD = 'nonstandard'
+
+
+# Get the public_key_type for a public key.
+# The types are PubKey, PubKeyECDSA, ScriptHash and NonStandard
+def get_public_key_type(public_key):
+    if public_key is None:
+        return None
+    public_key_bytes = bytes.fromhex(public_key)
+    if is_pay_to_pubkey(public_key_bytes):
+        return SCRIPT_CLASS_PUB_KEY
+    if is_pay_to_pubkey_ecdsa(public_key_bytes):
+        return SCRIPT_CLASS_PUB_KEY_ECDSA
+    if is_pay_to_script_hash(public_key_bytes):
+        return SCRIPT_CLASS_SCRIPT_HASH
+    return SCRIPT_CLASS_NON_STANDARD
+
+
+def is_pay_to_pubkey(public_key_bytes):
+    if len(public_key_bytes) == 34 and \
+            public_key_bytes[0] == 0x20 and \
+            public_key_bytes[33] == 0xac:
+        return True
+    return False
+
+
+def is_pay_to_pubkey_ecdsa(public_key_bytes):
+    if len(public_key_bytes) == 35 and \
+            public_key_bytes[0] == 0x21 and \
+            public_key_bytes[34] == 0xab:
+        return True
+    return False
+
+
+def is_pay_to_script_hash(public_key_bytes):
+    if len(public_key_bytes) == 35 and \
+            public_key_bytes[0] == 0xaa and \
+            public_key_bytes[1] == 0x20 and \
+            public_key_bytes[34] == 0x87:
+        return True
+    return False

--- a/models/Transaction.py
+++ b/models/Transaction.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, String, Integer, BigInteger, Boolean, Index
 from sqlalchemy.dialects.postgresql import ARRAY
 
 from dbsession import Base
+from helper.PublicKeyType import get_public_key_type
 
 
 class Transaction(Base):
@@ -29,8 +30,11 @@ class TransactionOutput(Base):
     amount = Column(BigInteger)
     script_public_key = Column(String)
     script_public_key_address = Column(String)
-    script_public_key_type = Column(String)
     accepting_block_hash = Column(String)
+
+    @property
+    def script_public_key_type(self):
+        return get_public_key_type(self.script_public_key)
 
 
 Index("idx_txouts", TransactionOutput.transaction_id)


### PR DESCRIPTION
Calculate TransactionOutput.script_public_key_type to avoid having to store it in the database.